### PR TITLE
Make private-ops deployment branch configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ steps:
   - label: Run a common script to setup gitconfig
     command: .buildkite/common/scripts/setup_gitconfig.sh
     plugins:
-      # v0.1.0 immediately below is the git ref of the plugin. You can also use
+      # v0.1.1 immediately below is the git ref of the plugin. You can also use
       # branches or commit SHA
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 
-      # Example: Using a branch 
+      # Example: Using a branch
       # Note: buildkite caches plugin downloads so this is not recommended
       # - private-oasis-buildkite-tools#some/feature/branch: ~
 
@@ -42,7 +42,7 @@ steps:
   - label: Generate a set of generic checks
     command: .buildkite/common/pipelines/generic_checks.sh
     plugins:
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 This will then generate the following steps:
@@ -53,7 +53,7 @@ This will then generate the following steps:
 
 ## Available Common Scripts
 
-_Note: The examples show a plugin version of v0.1.0. You will want to use the
+_Note: The examples show a plugin version of v0.1.1. You will want to use the
 latest version instead._
 
 ### argbash_checks.sh
@@ -68,7 +68,7 @@ steps:
   - label: Run argbash check on directory1 and directory2
     command: .buildkite/common/scripts/argbash_checks.sh dir1/ dir2/
     plugins:
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ### build_tag_push_build_image.sh
@@ -83,7 +83,7 @@ steps:
   - label: Build tag and push a docker image
     command: .buildkite/common/scripts/build_tag_push_build_image.sh dockerrepo/name path/to/dockerfile
     plugins:
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ### get_docker_tag.sh
@@ -111,7 +111,7 @@ steps:
           volumes:
             - .:/workdir
 
-      - oasislabs/private-oasis-buildkite-tools#v0.1.0: ~
+      - oasislabs/private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ### promote_docker_image_to.sh
@@ -134,7 +134,7 @@ steps:
     command:
       - .buildkite/common/scripts/promote_docker_image_to.sh dockerrepo/name latest
     plugins:
-      - oasislabs/private-oasis-buildkite-tools#v0.1.0: ~
+      - oasislabs/private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ### set_docker_tag_meta_data.sh
@@ -151,7 +151,7 @@ steps:
     branches: master
     command: .buildkite/common/scripts/set_docker_tag_meta_data.sh
     plugins:
-      - oasislabs/private-oasis-buildkite-tools#v0.1.0: ~
+      - oasislabs/private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ### setup_gitconfig.sh
@@ -179,7 +179,7 @@ steps:
 
 ## Available Common Pipelines
 
-_Note: The examples show a plugin version of v0.1.0. You will want to use the
+_Note: The examples show a plugin version of v0.1.1. You will want to use the
 latest version instead._
 
 ### deployment_trigger.sh
@@ -197,13 +197,13 @@ steps:
     command: >
       .buildkite/common/pipelines/deployment_trigger.sh
       --deployment-branches "master"
-      project-name 
+      project-name
       staging
-      aws 
+      aws
       us-west-2
       project-chart-name
     plugins:
-      - oasislabs/private-oasis-buildkite-tools#v0.1.0: ~
+      - oasislabs/private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ### generic_checks.sh
@@ -221,7 +221,7 @@ steps:
   - label: Generate a set of generic checks
     command: .buildkite/common/pipelines/generic_checks.sh
     plugins:
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ### generic_docker_build_publish_and_deploy.sh
@@ -231,11 +231,11 @@ Generates a staging to production docker publishing and, optionally, deployment 
 1. Derive docker tag (using [set_docker_tag_meta_data.sh](#set_docker_tag_meta_datash))
 2. Build, tag, push a docker image for this build
 3. Promote the docker image to the `staging` docker tag
-4. If the `--trigger-deploy` flag is set, deploy the image to staging 
+4. If the `--trigger-deploy` flag is set, deploy the image to staging
    using the [generic deployment pipeline](https://buildkite.com/oasislabs/private-ops-deploy-any-chart/)
 5. Hold for a production promotion
 6. Promote the docker image to the `latest` docker tag
-7. If the `--trigger-deploy` flag is set, deploy the image to production 
+7. If the `--trigger-deploy` flag is set, deploy the image to production
    using the [generic deployment pipeline](https://buildkite.com/oasislabs/private-ops-deploy-any-chart/)
 
 This generic pipeline has many options. You can check out this repository and
@@ -253,13 +253,13 @@ $ common/pipelines/generic_docker_build_publish_and_deploy.sh --help
 ```
 steps:
   - label: Generate docker build and publish pipeline
-    command: > 
-      .buildkite/common/pipelines/generic_docker_build_publish_and_deploy.sh 
-      oasislabs/some-docker-repo 
-      some-chart-name 
+    command: >
+      .buildkite/common/pipelines/generic_docker_build_publish_and_deploy.sh
+      oasislabs/some-docker-repo
+      some-chart-name
       docker/Dockerfile
     plugins:
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ##### Create a docker build, publish, and deployment pipeline
@@ -267,14 +267,14 @@ steps:
 ```
 steps:
   - label: Generate docker build and publish pipeline
-    command: > 
-      .buildkite/common/pipelines/generic_docker_build_publish_and_deploy.sh 
+    command: >
+      .buildkite/common/pipelines/generic_docker_build_publish_and_deploy.sh
       --trigger-deploy
-      oasislabs/some-docker-repo 
-      some-chart-name 
+      oasislabs/some-docker-repo
+      some-chart-name
       docker/Dockerfile
     plugins:
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 ```
 
 ##### Create a docker build, publish, and deployment pipeline that deploys to ops-staging and ops-production
@@ -282,14 +282,14 @@ steps:
 ```
 steps:
   - label: Generate docker build and publish pipeline
-    command: > 
-      .buildkite/common/pipelines/generic_docker_build_publish_and_deploy.sh 
+    command: >
+      .buildkite/common/pipelines/generic_docker_build_publish_and_deploy.sh
       --trigger-deploy
-      --staging-environment ops-staging 
+      --staging-environment ops-staging
       --production-environment ops-production
-      oasislabs/some-docker-repo 
-      some-chart-name 
+      oasislabs/some-docker-repo
+      some-chart-name
       docker/Dockerfile
     plugins:
-      - private-oasis-buildkite-tools#v0.1.0: ~
+      - private-oasis-buildkite-tools#v0.1.1: ~
 ```

--- a/common/pipelines/deployment_trigger.sh
+++ b/common/pipelines/deployment_trigger.sh
@@ -11,6 +11,7 @@
 
 # ARG_OPTIONAL_BOOLEAN([output-only],[],[Do not call buildkite. Used for testing])
 # ARG_OPTIONAL_SINGLE([deployment-branches],[],[Branches to deploy],[master])
+# ARG_OPTIONAL_SINGLE([private-ops-deployment-branch],[],[Branch of private-ops to use for generic deploys],[master])
 # ARG_POSITIONAL_SINGLE([name],[name of the project])
 # ARG_POSITIONAL_SINGLE([deployment-environment],[target environment for deployment])
 # ARG_POSITIONAL_SINGLE([cloud-provider],[target cloud provider for deployment])
@@ -46,12 +47,13 @@ _positionals=()
 # THE DEFAULTS INITIALIZATION - OPTIONALS
 _arg_output_only="off"
 _arg_deployment_branches="master"
+_arg_private_ops_deployment_branch="master"
 
 
 print_help()
 {
 	printf '%s\n' "Generates a deployment trigger for a given chart to a given target"
-	printf 'Usage: %s [--(no-)output-only] [--deployment-branches <arg>] [-h|--help] <name> <deployment-environment> <cloud-provider> <region> <chart-name>\n' "$0"
+	printf 'Usage: %s [--(no-)output-only] [--deployment-branches <arg>] [--private-ops-deployment-branch <arg>] [-h|--help] <name> <deployment-environment> <cloud-provider> <region> <chart-name>\n' "$0"
 	printf '\t%s\n' "<name>: name of the project"
 	printf '\t%s\n' "<deployment-environment>: target environment for deployment"
 	printf '\t%s\n' "<cloud-provider>: target cloud provider for deployment"
@@ -59,6 +61,7 @@ print_help()
 	printf '\t%s\n' "<chart-name>: chart-name to deploy"
 	printf '\t%s\n' "--output-only, --no-output-only: Do not call buildkite. Used for testing (off by default)"
 	printf '\t%s\n' "--deployment-branches: Branches to deploy (default: 'master')"
+	printf '\t%s\n' "--private-ops-deployment-branch: Branch of private-ops to use for generic deploys (default: 'master')"
 	printf '\t%s\n' "-h, --help: Prints help"
 }
 
@@ -81,6 +84,14 @@ parse_commandline()
 				;;
 			--deployment-branches=*)
 				_arg_deployment_branches="${_key##--deployment-branches=}"
+				;;
+			--private-ops-deployment-branch)
+				test $# -lt 2 && die "Missing value for the optional argument '$_key'." 1
+				_arg_private_ops_deployment_branch="$2"
+				shift
+				;;
+			--private-ops-deployment-branch=*)
+				_arg_private_ops_deployment_branch="${_key##--private-ops-deployment-branch=}"
 				;;
 			-h|--help)
 				print_help
@@ -168,7 +179,7 @@ steps:
     build:
       message: "Deploy $CHART_NAME chart to $DEPLOYMENT_ENVIRONMENT"
       commit: "HEAD"
-      branch: "ravenac95/feature/generic-deploy"
+      branch: "$_arg_private_ops_deployment_branch"
       env:
         ENVIRONMENT: $DEPLOYMENT_ENVIRONMENT
         CLOUD_PROVIDER: $CLOUD_PROVIDER


### PR DESCRIPTION
I missed this clean up task. I was supposed to set the generic-deploy branch to master but instead left it as the in development branch. This change will use `master` on private-ops by default but allows us to test different branches for generic deploys if necessary.